### PR TITLE
wrong version

### DIFF
--- a/src/Ratchet/ConnectionInterface.php
+++ b/src/Ratchet/ConnectionInterface.php
@@ -6,7 +6,7 @@ namespace Ratchet;
  * The version of Ratchet being used
  * @var string
  */
-const VERSION = 'Ratchet/1.0.1';
+const VERSION = 'Ratchet/1.0.3';
 
 /**
  * A proxy object representing a connection to the application


### PR DESCRIPTION
+ it should reflect the current version
+ i would recommend to generally hide the x-powered-by header, or at least add an option to hide... or provided the current library version :-)