### PR TITLE
WsServer - ability to set maxMessagePayloadSize and maxFramePayloadSize

### DIFF
--- a/src/Ratchet/WebSocket/WsServer.php
+++ b/src/Ratchet/WebSocket/WsServer.php
@@ -64,11 +64,14 @@ class WsServer implements HttpServerInterface
      */
     private $msgCb;
 
+    private $maxMessagePayloadSize;
+    private $maxFramePayloadSize;
+
     /**
      * @param \Ratchet\WebSocket\MessageComponentInterface|\Ratchet\MessageComponentInterface $component Your application to run with WebSockets
      * @note If you want to enable sub-protocols have your component implement WsServerInterface as well
      */
-    public function __construct(ComponentInterface $component)
+    public function __construct(ComponentInterface $component, $maxMessagePayloadSize = null, $maxFramePayloadSize = null)
     {
         if ($component instanceof MessageComponentInterface) {
             $this->msgCb = function (ConnectionInterface $conn, MessageInterface $msg) {
@@ -104,6 +107,9 @@ class WsServer implements HttpServerInterface
         $this->ueFlowFactory = function () use ($reusableUnderflowException) {
             return $reusableUnderflowException;
         };
+
+        $this->maxMessagePayloadSize = $maxMessagePayloadSize;
+        $this->maxFramePayloadSize = $maxFramePayloadSize;
     }
 
     /**
@@ -140,7 +146,9 @@ class WsServer implements HttpServerInterface
                 $this->onControlFrame($frame, $wsConn);
             },
             true,
-            $this->ueFlowFactory
+            $this->ueFlowFactory,
+            $this->maxMessagePayloadSize,
+            $this->maxFramePayloadSize
         );
 
         $this->connections->attach($conn, new ConnContext($wsConn, $streamer));


### PR DESCRIPTION
For the moment both values are 25% of memory limit `ini_get('memory_limit')`. This change allows to set limits as needed for a given project.

Example from one of my projects, where message size limit is 0.5 MB:
```php
class Websocket implements MessageComponentInterface {
    protected $_clients;
    protected $_server;
  
    public function __construct($port=8443, $maxMessagePayloadSize=null, $maxFramePayloadSize=null){
	  $this->_clients = new \SplObjectStorage;
	  $this->_server = IoServer::factory(new HttpServer(new WsServer($this, $maxMessagePayloadSize, $maxFramePayloadSize)), $port);
	  $this->_server->run();
    }
}

new Websocket(8443, 512 * 1024);
```