### PR TITLE
Fix Class "Nyholm\Psr7\Factory\Psr17Factory" not found

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
     "react/event-loop": "^1.4.0",
     "guzzlehttp/psr7": "^2.5.0",
     "symfony/http-foundation": "^5.4.24 || ^6.0 || ^7.0",
-    "symfony/routing": "^5.4.22 || ^6.0 || ^7.0"
+    "symfony/routing": "^5.4.22 || ^6.0 || ^7.0",
+    "nyholm/psr7": "^1.8"
   },
   "config": {
     "platform": {


### PR DESCRIPTION
```
[2025-03-10T12:56:35.586072+00:00] movim.ERROR: Error: Class "Nyholm\Psr7\Factory\Psr17Factory" not found in /var/www/html/movim/vendor/plesk/ratchetphp/src/Ratchet/WebSocket/WsServer.php (line 103)
Trace
#0 /var/www/html/movim/src/Movim/Console/DaemonCommand.php(119): Ratchet\WebSocket\WsServer->__construct()
#1 /var/www/html/movim/vendor/symfony/console/Command/Command.php(326): Movim\Console\DaemonCommand->execute()
#2 /var/www/html/movim/vendor/symfony/console/Application.php(1078): Symfony\Component\Console\Command\Command->run()
#3 /var/www/html/movim/vendor/symfony/console/Application.php(324): Symfony\Component\Console\Application->doRunCommand()
#4 /var/www/html/movim/vendor/symfony/console/Application.php(175): Symfony\Component\Console\Application->doRun()
#5 /var/www/html/movim/daemon.php(22): Symfony\Component\Console\Application->run()
#6 {main}  
```